### PR TITLE
feat(identity): add external identity linking and profile merge

### DIFF
--- a/DKH.CustomerService.Api/Program.cs
+++ b/DKH.CustomerService.Api/Program.cs
@@ -45,6 +45,7 @@ await Platform
         grpc.MapService<ContactVerificationGrpcService>();
         grpc.MapService<CustomerCrudGrpcService>();
         grpc.MapService<CustomerManagementGrpcService>();
+        grpc.MapService<IdentityLinkingGrpcService>();
         grpc.MapService<DataExchangeService>();
         grpc.ConfigureDefaultRoute("CustomerService gRPC is running.");
     })

--- a/DKH.CustomerService.Api/Services/IdentityLinkingGrpcService.cs
+++ b/DKH.CustomerService.Api/Services/IdentityLinkingGrpcService.cs
@@ -1,0 +1,93 @@
+using DKH.CustomerService.Application.ExternalIdentities.FindByExternalIdentity;
+using DKH.CustomerService.Application.ExternalIdentities.LinkIdentity;
+using DKH.CustomerService.Application.ExternalIdentities.ListIdentities;
+using DKH.CustomerService.Application.ExternalIdentities.UnlinkIdentity;
+using DKH.Platform.Grpc.Common.Types;
+using DKH.Platform.MultiTenancy;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using MediatR;
+using ContractsModels = DKH.CustomerService.Contracts.Customer.Models;
+using ContractsServices = DKH.CustomerService.Contracts.Customer.Api.IdentityLinking.v1;
+
+namespace DKH.CustomerService.Api.Services;
+
+public sealed class IdentityLinkingGrpcService(IMediator mediator, IPlatformStorefrontContext storefrontContext)
+    : ContractsServices.IdentityLinkingService.IdentityLinkingServiceBase
+{
+    private readonly IMediator _mediator = mediator;
+    private readonly IPlatformStorefrontContext _storefrontContext = storefrontContext;
+
+    public override async Task<ContractsModels.ExternalIdentity.v1.ExternalIdentityModel> LinkIdentity(
+        ContractsServices.LinkIdentityRequest request,
+        ServerCallContext context)
+    {
+        var storefrontId = ResolveStorefrontId(request.StorefrontId);
+        return await _mediator.Send(
+            new LinkIdentityCommand(
+                storefrontId,
+                request.UserId,
+                request.Provider,
+                request.ProviderUserId,
+                string.IsNullOrEmpty(request.Email) ? null : request.Email,
+                string.IsNullOrEmpty(request.DisplayName) ? null : request.DisplayName,
+                request.IsPrimary),
+            context.CancellationToken);
+    }
+
+    public override async Task<Empty> UnlinkIdentity(
+        ContractsServices.UnlinkIdentityRequest request,
+        ServerCallContext context)
+    {
+        var storefrontId = ResolveStorefrontId(request.StorefrontId);
+        await _mediator.Send(
+            new UnlinkIdentityCommand(
+                storefrontId,
+                request.UserId,
+                request.IdentityId.ToGuid()),
+            context.CancellationToken);
+        return new Empty();
+    }
+
+    public override async Task<ContractsServices.ListIdentitiesResponse> ListIdentities(
+        ContractsServices.ListIdentitiesRequest request,
+        ServerCallContext context)
+    {
+        var storefrontId = ResolveStorefrontId(request.StorefrontId);
+        return await _mediator.Send(
+            new ListIdentitiesQuery(storefrontId, request.UserId),
+            context.CancellationToken);
+    }
+
+    public override async Task<ContractsModels.CustomerProfile.v1.CustomerProfileModel> FindByExternalIdentity(
+        ContractsServices.FindByExternalIdentityRequest request,
+        ServerCallContext context)
+    {
+        var storefrontId = ResolveStorefrontId(request.StorefrontId);
+        return await _mediator.Send(
+            new FindByExternalIdentityQuery(
+                storefrontId,
+                request.Provider,
+                request.ProviderUserId),
+            context.CancellationToken);
+    }
+
+    public override Task<ContractsModels.CustomerProfile.v1.CustomerProfileModel> MergeProfiles(
+        ContractsServices.MergeProfilesRequest request,
+        ServerCallContext context)
+    {
+        // MergeProfiles will be implemented in Phase 4 (Issue #31)
+        throw new RpcException(new Status(StatusCode.Unimplemented, "MergeProfiles will be implemented in Phase 4."));
+    }
+
+    private Guid ResolveStorefrontId(GuidValue? requestStorefrontId)
+    {
+        if (requestStorefrontId is not null)
+        {
+            return requestStorefrontId.ToGuid();
+        }
+
+        return _storefrontContext.StorefrontId
+               ?? throw new RpcException(new Status(StatusCode.InvalidArgument, "Storefront ID is required"));
+    }
+}

--- a/DKH.CustomerService.Api/Services/IdentityLinkingGrpcService.cs
+++ b/DKH.CustomerService.Api/Services/IdentityLinkingGrpcService.cs
@@ -1,6 +1,7 @@
 using DKH.CustomerService.Application.ExternalIdentities.FindByExternalIdentity;
 using DKH.CustomerService.Application.ExternalIdentities.LinkIdentity;
 using DKH.CustomerService.Application.ExternalIdentities.ListIdentities;
+using DKH.CustomerService.Application.ExternalIdentities.MergeProfiles;
 using DKH.CustomerService.Application.ExternalIdentities.UnlinkIdentity;
 using DKH.Platform.Grpc.Common.Types;
 using DKH.Platform.MultiTenancy;
@@ -72,12 +73,17 @@ public sealed class IdentityLinkingGrpcService(IMediator mediator, IPlatformStor
             context.CancellationToken);
     }
 
-    public override Task<ContractsModels.CustomerProfile.v1.CustomerProfileModel> MergeProfiles(
+    public override async Task<ContractsModels.CustomerProfile.v1.CustomerProfileModel> MergeProfiles(
         ContractsServices.MergeProfilesRequest request,
         ServerCallContext context)
     {
-        // MergeProfiles will be implemented in Phase 4 (Issue #31)
-        throw new RpcException(new Status(StatusCode.Unimplemented, "MergeProfiles will be implemented in Phase 4."));
+        var storefrontId = ResolveStorefrontId(request.StorefrontId);
+        return await _mediator.Send(
+            new MergeProfilesCommand(
+                storefrontId,
+                request.SourceUserId,
+                request.TargetUserId),
+            context.CancellationToken);
     }
 
     private Guid ResolveStorefrontId(GuidValue? requestStorefrontId)

--- a/DKH.CustomerService.Application/Abstractions/ICustomerRepository.cs
+++ b/DKH.CustomerService.Application/Abstractions/ICustomerRepository.cs
@@ -18,6 +18,22 @@ public interface ICustomerRepository
 
     Task DeleteAsync(CustomerProfileEntity entity, CancellationToken cancellationToken = default);
 
+    Task<CustomerProfileEntity?> GetByExternalIdentityAsync(
+        Guid storefrontId,
+        string provider,
+        string providerUserId,
+        CancellationToken cancellationToken = default);
+
+    Task<CustomerProfileEntity?> GetByUserIdWithExternalIdentitiesAsync(
+        Guid storefrontId,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    Task<CustomerProfileEntity?> FindByEmailAcrossProvidersAsync(
+        Guid storefrontId,
+        string email,
+        CancellationToken cancellationToken = default);
+
     Task<(IReadOnlyList<CustomerProfileEntity> Items, int TotalCount)> SearchAsync(
         Guid? storefrontId,  // Nullable for admin - returns all customers when null
         string query,

--- a/DKH.CustomerService.Application/Abstractions/ICustomerRepository.cs
+++ b/DKH.CustomerService.Application/Abstractions/ICustomerRepository.cs
@@ -34,6 +34,11 @@ public interface ICustomerRepository
         string email,
         CancellationToken cancellationToken = default);
 
+    Task<CustomerProfileEntity?> GetByUserIdWithAllRelationsAsync(
+        Guid storefrontId,
+        string userId,
+        CancellationToken cancellationToken = default);
+
     Task<(IReadOnlyList<CustomerProfileEntity> Items, int TotalCount)> SearchAsync(
         Guid? storefrontId,  // Nullable for admin - returns all customers when null
         string query,

--- a/DKH.CustomerService.Application/ExternalIdentities/FindByExternalIdentity/FindByExternalIdentityQuery.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/FindByExternalIdentity/FindByExternalIdentityQuery.cs
@@ -1,0 +1,9 @@
+using DKH.CustomerService.Contracts.Customer.Models.CustomerProfile.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.FindByExternalIdentity;
+
+public sealed record FindByExternalIdentityQuery(
+    Guid StorefrontId,
+    string Provider,
+    string ProviderUserId)
+    : IRequest<CustomerProfileModel>;

--- a/DKH.CustomerService.Application/ExternalIdentities/FindByExternalIdentity/FindByExternalIdentityQueryHandler.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/FindByExternalIdentity/FindByExternalIdentityQueryHandler.cs
@@ -1,0 +1,21 @@
+using DKH.CustomerService.Application.Mappers;
+using DKH.CustomerService.Contracts.Customer.Models.CustomerProfile.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.FindByExternalIdentity;
+
+public class FindByExternalIdentityQueryHandler(ICustomerRepository repository)
+    : IRequestHandler<FindByExternalIdentityQuery, CustomerProfileModel>
+{
+    public async Task<CustomerProfileModel> Handle(FindByExternalIdentityQuery request, CancellationToken cancellationToken)
+    {
+        var profile = await repository.GetByExternalIdentityAsync(
+            request.StorefrontId,
+            request.Provider,
+            request.ProviderUserId,
+            cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Customer profile not found for provider '{request.Provider}' with user ID '{request.ProviderUserId}'.");
+
+        return profile.ToContractModel();
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/LinkIdentity/LinkIdentityCommand.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/LinkIdentity/LinkIdentityCommand.cs
@@ -1,0 +1,13 @@
+using DKH.CustomerService.Contracts.Customer.Models.ExternalIdentity.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.LinkIdentity;
+
+public sealed record LinkIdentityCommand(
+    Guid StorefrontId,
+    string UserId,
+    string Provider,
+    string ProviderUserId,
+    string? Email,
+    string? DisplayName,
+    bool IsPrimary)
+    : IRequest<ExternalIdentityModel>;

--- a/DKH.CustomerService.Application/ExternalIdentities/LinkIdentity/LinkIdentityCommandHandler.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/LinkIdentity/LinkIdentityCommandHandler.cs
@@ -1,0 +1,29 @@
+using DKH.CustomerService.Application.Mappers;
+using DKH.CustomerService.Contracts.Customer.Models.ExternalIdentity.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.LinkIdentity;
+
+public class LinkIdentityCommandHandler(ICustomerRepository repository)
+    : IRequestHandler<LinkIdentityCommand, ExternalIdentityModel>
+{
+    public async Task<ExternalIdentityModel> Handle(LinkIdentityCommand request, CancellationToken cancellationToken)
+    {
+        var profile = await repository.GetByUserIdWithExternalIdentitiesAsync(
+            request.StorefrontId,
+            request.UserId,
+            cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Customer profile not found for user '{request.UserId}' in storefront '{request.StorefrontId}'.");
+
+        var identity = profile.AddExternalIdentity(
+            request.Provider,
+            request.ProviderUserId,
+            request.Email,
+            request.DisplayName,
+            request.IsPrimary);
+
+        await repository.UpdateAsync(profile, cancellationToken);
+
+        return identity.ToContractModel();
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/LinkIdentity/LinkIdentityCommandValidator.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/LinkIdentity/LinkIdentityCommandValidator.cs
@@ -1,0 +1,14 @@
+namespace DKH.CustomerService.Application.ExternalIdentities.LinkIdentity;
+
+public class LinkIdentityCommandValidator : AbstractValidator<LinkIdentityCommand>
+{
+    public LinkIdentityCommandValidator()
+    {
+        RuleFor(x => x.StorefrontId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.Provider).NotEmpty().MaximumLength(50);
+        RuleFor(x => x.ProviderUserId).NotEmpty().MaximumLength(256);
+        RuleFor(x => x.Email).MaximumLength(256).EmailAddress().When(x => !string.IsNullOrEmpty(x.Email));
+        RuleFor(x => x.DisplayName).MaximumLength(200);
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/ListIdentities/ListIdentitiesQuery.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/ListIdentities/ListIdentitiesQuery.cs
@@ -1,0 +1,8 @@
+using DKH.CustomerService.Contracts.Customer.Api.IdentityLinking.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.ListIdentities;
+
+public sealed record ListIdentitiesQuery(
+    Guid StorefrontId,
+    string UserId)
+    : IRequest<ListIdentitiesResponse>;

--- a/DKH.CustomerService.Application/ExternalIdentities/ListIdentities/ListIdentitiesQueryHandler.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/ListIdentities/ListIdentitiesQueryHandler.cs
@@ -1,0 +1,22 @@
+using DKH.CustomerService.Application.Mappers;
+using DKH.CustomerService.Contracts.Customer.Api.IdentityLinking.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.ListIdentities;
+
+public class ListIdentitiesQueryHandler(ICustomerRepository repository)
+    : IRequestHandler<ListIdentitiesQuery, ListIdentitiesResponse>
+{
+    public async Task<ListIdentitiesResponse> Handle(ListIdentitiesQuery request, CancellationToken cancellationToken)
+    {
+        var profile = await repository.GetByUserIdWithExternalIdentitiesAsync(
+            request.StorefrontId,
+            request.UserId,
+            cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Customer profile not found for user '{request.UserId}' in storefront '{request.StorefrontId}'.");
+
+        var response = new ListIdentitiesResponse();
+        response.Items.AddRange(profile.ExternalIdentities.Select(e => e.ToContractModel()));
+        return response;
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/MergeProfiles/MergeProfilesCommand.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/MergeProfiles/MergeProfilesCommand.cs
@@ -1,0 +1,9 @@
+using DKH.CustomerService.Contracts.Customer.Models.CustomerProfile.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.MergeProfiles;
+
+public sealed record MergeProfilesCommand(
+    Guid StorefrontId,
+    string SourceUserId,
+    string TargetUserId)
+    : IRequest<CustomerProfileModel>;

--- a/DKH.CustomerService.Application/ExternalIdentities/MergeProfiles/MergeProfilesCommandHandler.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/MergeProfiles/MergeProfilesCommandHandler.cs
@@ -1,0 +1,31 @@
+using DKH.CustomerService.Application.Mappers;
+using DKH.CustomerService.Contracts.Customer.Models.CustomerProfile.v1;
+
+namespace DKH.CustomerService.Application.ExternalIdentities.MergeProfiles;
+
+public class MergeProfilesCommandHandler(ICustomerRepository repository)
+    : IRequestHandler<MergeProfilesCommand, CustomerProfileModel>
+{
+    public async Task<CustomerProfileModel> Handle(
+        MergeProfilesCommand request,
+        CancellationToken cancellationToken)
+    {
+        var sourceProfile = await repository.GetByUserIdWithAllRelationsAsync(
+            request.StorefrontId, request.SourceUserId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Source profile with userId '{request.SourceUserId}' not found in storefront '{request.StorefrontId}'.");
+
+        var targetProfile = await repository.GetByUserIdWithAllRelationsAsync(
+            request.StorefrontId, request.TargetUserId, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Target profile with userId '{request.TargetUserId}' not found in storefront '{request.StorefrontId}'.");
+
+        targetProfile.MergeFrom(sourceProfile);
+        sourceProfile.SoftDelete();
+
+        await repository.UpdateAsync(targetProfile, cancellationToken);
+        await repository.UpdateAsync(sourceProfile, cancellationToken);
+
+        return targetProfile.ToContractModel();
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/MergeProfiles/MergeProfilesCommandValidator.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/MergeProfiles/MergeProfilesCommandValidator.cs
@@ -1,0 +1,14 @@
+namespace DKH.CustomerService.Application.ExternalIdentities.MergeProfiles;
+
+public class MergeProfilesCommandValidator : AbstractValidator<MergeProfilesCommand>
+{
+    public MergeProfilesCommandValidator()
+    {
+        RuleFor(x => x.StorefrontId).NotEmpty();
+        RuleFor(x => x.SourceUserId).NotEmpty();
+        RuleFor(x => x.TargetUserId).NotEmpty();
+        RuleFor(x => x)
+            .Must(x => x.SourceUserId != x.TargetUserId)
+            .WithMessage("Source and target user IDs must be different.");
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/UnlinkIdentity/UnlinkIdentityCommand.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/UnlinkIdentity/UnlinkIdentityCommand.cs
@@ -1,0 +1,7 @@
+namespace DKH.CustomerService.Application.ExternalIdentities.UnlinkIdentity;
+
+public sealed record UnlinkIdentityCommand(
+    Guid StorefrontId,
+    string UserId,
+    Guid IdentityId)
+    : IRequest;

--- a/DKH.CustomerService.Application/ExternalIdentities/UnlinkIdentity/UnlinkIdentityCommandHandler.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/UnlinkIdentity/UnlinkIdentityCommandHandler.cs
@@ -1,0 +1,19 @@
+namespace DKH.CustomerService.Application.ExternalIdentities.UnlinkIdentity;
+
+public class UnlinkIdentityCommandHandler(ICustomerRepository repository)
+    : IRequestHandler<UnlinkIdentityCommand>
+{
+    public async Task Handle(UnlinkIdentityCommand request, CancellationToken cancellationToken)
+    {
+        var profile = await repository.GetByUserIdWithExternalIdentitiesAsync(
+            request.StorefrontId,
+            request.UserId,
+            cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Customer profile not found for user '{request.UserId}' in storefront '{request.StorefrontId}'.");
+
+        profile.RemoveExternalIdentity(request.IdentityId);
+
+        await repository.UpdateAsync(profile, cancellationToken);
+    }
+}

--- a/DKH.CustomerService.Application/ExternalIdentities/UnlinkIdentity/UnlinkIdentityCommandValidator.cs
+++ b/DKH.CustomerService.Application/ExternalIdentities/UnlinkIdentity/UnlinkIdentityCommandValidator.cs
@@ -1,0 +1,11 @@
+namespace DKH.CustomerService.Application.ExternalIdentities.UnlinkIdentity;
+
+public class UnlinkIdentityCommandValidator : AbstractValidator<UnlinkIdentityCommand>
+{
+    public UnlinkIdentityCommandValidator()
+    {
+        RuleFor(x => x.StorefrontId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.IdentityId).NotEmpty();
+    }
+}

--- a/DKH.CustomerService.Application/Mappers/ExternalIdentityMapper.cs
+++ b/DKH.CustomerService.Application/Mappers/ExternalIdentityMapper.cs
@@ -1,0 +1,24 @@
+using DKH.CustomerService.Contracts.Customer.Models.ExternalIdentity.v1;
+using DKH.CustomerService.Domain.Entities.ExternalIdentity;
+using DKH.Platform.Grpc.Common.Types;
+using Google.Protobuf.WellKnownTypes;
+
+namespace DKH.CustomerService.Application.Mappers;
+
+public static class ExternalIdentityMapper
+{
+    public static ExternalIdentityModel ToContractModel(this CustomerExternalIdentityEntity entity)
+    {
+        return new ExternalIdentityModel
+        {
+            Id = GuidValue.FromGuid(entity.Id),
+            CustomerId = GuidValue.FromGuid(entity.CustomerId),
+            Provider = entity.Provider,
+            ProviderUserId = entity.ProviderUserId,
+            Email = entity.Email ?? string.Empty,
+            DisplayName = entity.DisplayName ?? string.Empty,
+            IsPrimary = entity.IsPrimary,
+            LinkedAt = Timestamp.FromDateTime(DateTime.SpecifyKind(entity.LinkedAt, DateTimeKind.Utc)),
+        };
+    }
+}

--- a/DKH.CustomerService.Contracts/DKH.CustomerService.Contracts.csproj
+++ b/DKH.CustomerService.Contracts/DKH.CustomerService.Contracts.csproj
@@ -19,6 +19,8 @@
     <Protobuf Include="proto/customer/api/customer_preferences_management/v1/customer_preferences_management_service.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
     <Protobuf Include="proto/customer/api/contact_verification/v1/contact_verification_service.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
     <Protobuf Include="proto/customer/api/data_exchange/v1/data_exchange_service.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
+    <Protobuf Include="proto/customer/api/identity_linking/v1/identity_linking_service.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
+    <Protobuf Include="proto/customer/models/external_identity/v1/external_identity.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
     <Protobuf Include="proto/customer/models/customer_profile/v1/customer_profile.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
     <Protobuf Include="proto/customer/models/customer_address/v1/customer_address.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>
     <Protobuf Include="proto/customer/models/wishlist_item/v1/wishlist_item.proto" ProtoRoot="proto" AdditionalProtocArguments="--proto_path=$(DKHPlatformGrpcCommonProtoPath)"/>

--- a/DKH.CustomerService.Contracts/proto/customer/api/identity_linking/v1/identity_linking_service.proto
+++ b/DKH.CustomerService.Contracts/proto/customer/api/identity_linking/v1/identity_linking_service.proto
@@ -1,0 +1,96 @@
+syntax = "proto3";
+
+package proto.customer.api.identity_linking.v1;
+
+option csharp_namespace = "DKH.CustomerService.Contracts.Customer.Api.IdentityLinking.v1";
+
+import "google/protobuf/empty.proto";
+import "customer/models/external_identity/v1/external_identity.proto";
+import "customer/models/customer_profile/v1/customer_profile.proto";
+import "types/guid.proto";
+
+// IdentityLinkingService manages external identity linking for customer profiles.
+service IdentityLinkingService {
+  // Link an external identity to a customer profile
+  rpc LinkIdentity(LinkIdentityRequest) returns (proto.customer.models.external_identity.v1.ExternalIdentityModel);
+
+  // Unlink an external identity from a customer profile
+  rpc UnlinkIdentity(UnlinkIdentityRequest) returns (google.protobuf.Empty);
+
+  // List all external identities linked to a customer profile
+  rpc ListIdentities(ListIdentitiesRequest) returns (ListIdentitiesResponse);
+
+  // Find a customer profile by external identity (provider + providerUserId)
+  rpc FindByExternalIdentity(FindByExternalIdentityRequest) returns (proto.customer.models.customer_profile.v1.CustomerProfileModel);
+
+  // Merge two customer profiles (source into target)
+  rpc MergeProfiles(MergeProfilesRequest) returns (proto.customer.models.customer_profile.v1.CustomerProfileModel);
+}
+
+message LinkIdentityRequest {
+  // Required - storefront scope
+  proto.platform.grpc.common.types.GuidValue storefront_id = 1;
+
+  // Required - user ID of the customer to link to
+  string user_id = 2;
+
+  // Required - identity provider name (e.g., "Telegram", "Google", "Microsoft")
+  string provider = 3;
+
+  // Required - user ID from the external provider
+  string provider_user_id = 4;
+
+  // Optional - email associated with this external identity
+  string email = 5;
+
+  // Optional - display name from the external provider
+  string display_name = 6;
+
+  // Whether this should be the primary identity
+  bool is_primary = 7;
+}
+
+message UnlinkIdentityRequest {
+  // Required - storefront scope
+  proto.platform.grpc.common.types.GuidValue storefront_id = 1;
+
+  // Required - user ID of the customer
+  string user_id = 2;
+
+  // Required - ID of the external identity to unlink
+  proto.platform.grpc.common.types.GuidValue identity_id = 3;
+}
+
+message ListIdentitiesRequest {
+  // Required - storefront scope
+  proto.platform.grpc.common.types.GuidValue storefront_id = 1;
+
+  // Required - user ID of the customer
+  string user_id = 2;
+}
+
+message ListIdentitiesResponse {
+  repeated proto.customer.models.external_identity.v1.ExternalIdentityModel items = 1;
+}
+
+message FindByExternalIdentityRequest {
+  // Required - storefront scope
+  proto.platform.grpc.common.types.GuidValue storefront_id = 1;
+
+  // Required - identity provider name
+  string provider = 2;
+
+  // Required - user ID from the external provider
+  string provider_user_id = 3;
+}
+
+message MergeProfilesRequest {
+  // Required - storefront scope
+  proto.platform.grpc.common.types.GuidValue storefront_id = 1;
+
+  // Required - user ID of the source profile (will be soft-deleted)
+  string source_user_id = 2;
+
+  // Required - user ID of the target profile (will receive merged data)
+  string target_user_id = 3;
+}

--- a/DKH.CustomerService.Contracts/proto/customer/models/customer_profile/v1/customer_profile.proto
+++ b/DKH.CustomerService.Contracts/proto/customer/models/customer_profile/v1/customer_profile.proto
@@ -6,6 +6,7 @@ option csharp_namespace = "DKH.CustomerService.Contracts.Customer.Models.Custome
 
 import "google/protobuf/timestamp.proto";
 import "types/guid.proto";
+import "customer/models/external_identity/v1/external_identity.proto";
 
 message CustomerProfileModel {
   proto.platform.grpc.common.types.GuidValue id = 1;
@@ -26,6 +27,7 @@ message CustomerProfileModel {
   ContactVerificationModel contact_verification = 16;
   string provider_type = 17;
   bool is_premium = 18;
+  repeated proto.customer.models.external_identity.v1.ExternalIdentityModel external_identities = 19;
 }
 
 message AccountStatusModel {

--- a/DKH.CustomerService.Contracts/proto/customer/models/external_identity/v1/external_identity.proto
+++ b/DKH.CustomerService.Contracts/proto/customer/models/external_identity/v1/external_identity.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package proto.customer.models.external_identity.v1;
+
+option csharp_namespace = "DKH.CustomerService.Contracts.Customer.Models.ExternalIdentity.v1";
+
+import "google/protobuf/timestamp.proto";
+import "types/guid.proto";
+
+message ExternalIdentityModel {
+  proto.platform.grpc.common.types.GuidValue id = 1;
+  proto.platform.grpc.common.types.GuidValue customer_id = 2;
+  string provider = 3;
+  string provider_user_id = 4;
+  string email = 5;
+  string display_name = 6;
+  bool is_primary = 7;
+  google.protobuf.Timestamp linked_at = 8;
+}

--- a/DKH.CustomerService.Domain/Entities/ExternalIdentity/CustomerExternalIdentityEntity.cs
+++ b/DKH.CustomerService.Domain/Entities/ExternalIdentity/CustomerExternalIdentityEntity.cs
@@ -1,0 +1,84 @@
+using DKH.Platform.Domain.Entities.Auditing;
+
+namespace DKH.CustomerService.Domain.Entities.ExternalIdentity;
+
+public sealed class CustomerExternalIdentityEntity : FullAuditedEntityWithKey<Guid>
+{
+    private CustomerExternalIdentityEntity()
+    {
+        Id = Guid.Empty;
+        CustomerId = Guid.Empty;
+        Provider = string.Empty;
+        ProviderUserId = string.Empty;
+    }
+
+    private CustomerExternalIdentityEntity(
+        Guid customerId,
+        string provider,
+        string providerUserId,
+        string? email,
+        string? displayName,
+        bool isPrimary)
+        : base(Guid.NewGuid())
+    {
+        CustomerId = customerId;
+        Provider = Require(provider, nameof(provider));
+        ProviderUserId = Require(providerUserId, nameof(providerUserId));
+        Email = email;
+        DisplayName = displayName;
+        IsPrimary = isPrimary;
+        LinkedAt = DateTime.UtcNow;
+    }
+
+    public Guid CustomerId { get; private set; }
+
+    public string Provider { get; private set; }
+
+    public string ProviderUserId { get; private set; }
+
+    public string? Email { get; private set; }
+
+    public string? DisplayName { get; private set; }
+
+    public bool IsPrimary { get; private set; }
+
+    public DateTime LinkedAt { get; private set; }
+
+    public override object?[] GetKeys() => [Id];
+
+    public static CustomerExternalIdentityEntity Create(
+        Guid customerId,
+        string provider,
+        string providerUserId,
+        string? email = null,
+        string? displayName = null,
+        bool isPrimary = false)
+    {
+        return new CustomerExternalIdentityEntity(customerId, provider, providerUserId, email, displayName, isPrimary);
+    }
+
+    public void SetPrimary(bool isPrimary)
+    {
+        IsPrimary = isPrimary;
+    }
+
+    public void UpdateEmail(string? email)
+    {
+        Email = email;
+    }
+
+    public void UpdateDisplayName(string? displayName)
+    {
+        DisplayName = displayName;
+    }
+
+    private static string Require(string value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{name} must be provided", name);
+        }
+
+        return value;
+    }
+}

--- a/DKH.CustomerService.Infrastructure/Persistence/AppDbContext.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/AppDbContext.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using DKH.CustomerService.Application.Abstractions;
 using DKH.CustomerService.Domain.Entities.CustomerAddress;
 using DKH.CustomerService.Domain.Entities.CustomerProfile;
+using DKH.CustomerService.Domain.Entities.ExternalIdentity;
 using DKH.CustomerService.Domain.Entities.WishlistItem;
 using DKH.Platform.EntityFrameworkCore;
 using DKH.Platform.Identity;
@@ -19,6 +20,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options)
     public DbSet<CustomerAddressEntity> CustomerAddresses { get; init; } = null!;
 
     public DbSet<WishlistItemEntity> WishlistItems { get; init; } = null!;
+
+    public DbSet<CustomerExternalIdentityEntity> ExternalIdentities { get; init; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/DKH.CustomerService.Infrastructure/Persistence/Configurations/CustomerExternalIdentityConfiguration.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/Configurations/CustomerExternalIdentityConfiguration.cs
@@ -1,0 +1,29 @@
+using DKH.CustomerService.Domain.Entities.ExternalIdentity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DKH.CustomerService.Infrastructure.Persistence.Configurations;
+
+public class CustomerExternalIdentityConfiguration : IEntityTypeConfiguration<CustomerExternalIdentityEntity>
+{
+    public void Configure(EntityTypeBuilder<CustomerExternalIdentityEntity> builder)
+    {
+        builder.ToTable("customer_external_identities");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id).IsRequired();
+        builder.Property(x => x.CustomerId).HasColumnName("customer_id").IsRequired();
+        builder.Property(x => x.Provider).HasColumnName("provider").HasMaxLength(50).IsRequired();
+        builder.Property(x => x.ProviderUserId).HasColumnName("provider_user_id").HasMaxLength(256).IsRequired();
+        builder.Property(x => x.Email).HasColumnName("email").HasMaxLength(256);
+        builder.Property(x => x.DisplayName).HasColumnName("display_name").HasMaxLength(200);
+        builder.Property(x => x.IsPrimary).HasColumnName("is_primary").HasDefaultValue(false);
+        builder.Property(x => x.LinkedAt).HasColumnName("linked_at").IsRequired();
+
+        builder.HasIndex(x => new { x.Provider, x.ProviderUserId }).IsUnique();
+        builder.HasIndex(x => x.CustomerId);
+        builder.HasIndex(x => new { x.Provider, x.Email });
+
+        builder.HasQueryFilter(x => !x.IsDeleted);
+    }
+}

--- a/DKH.CustomerService.Infrastructure/Persistence/Configurations/CustomerProfileConfiguration.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/Configurations/CustomerProfileConfiguration.cs
@@ -74,6 +74,11 @@ public class CustomerProfileConfiguration : IEntityTypeConfiguration<CustomerPro
             .HasForeignKey(x => x.CustomerId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.HasMany(x => x.ExternalIdentities)
+            .WithOne()
+            .HasForeignKey(x => x.CustomerId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         builder.HasIndex(x => new { x.StorefrontId, x.UserId }).IsUnique();
         builder.HasIndex(x => x.Email);
         builder.HasIndex(x => x.Phone);

--- a/DKH.CustomerService.Infrastructure/Persistence/Migrations/20260220024701_AddExternalIdentities.Designer.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/Migrations/20260220024701_AddExternalIdentities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DKH.CustomerService.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DKH.CustomerService.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260220024701_AddExternalIdentities")]
+    partial class AddExternalIdentities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DKH.CustomerService.Infrastructure/Persistence/Migrations/20260220024701_AddExternalIdentities.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/Migrations/20260220024701_AddExternalIdentities.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DKH.CustomerService.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalIdentities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "customer_external_identities",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    customer_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    provider = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    provider_user_id = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    display_name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    is_primary = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    linked_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uuid", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastModifierId = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeleterId = table.Column<Guid>(type: "uuid", nullable: true),
+                    DeletionTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_customer_external_identities", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_customer_external_identities_customer_profiles_customer_id",
+                        column: x => x.customer_id,
+                        principalTable: "customer_profiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_customer_external_identities_customer_id",
+                table: "customer_external_identities",
+                column: "customer_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_customer_external_identities_provider_email",
+                table: "customer_external_identities",
+                columns: new[] { "provider", "email" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_customer_external_identities_provider_provider_user_id",
+                table: "customer_external_identities",
+                columns: new[] { "provider", "provider_user_id" },
+                unique: true);
+
+            // Seed external identities from existing customer profiles
+            migrationBuilder.Sql("""
+                INSERT INTO customer_external_identities (
+                    "Id", customer_id, provider, provider_user_id, email,
+                    display_name, is_primary, linked_at,
+                    "CreationTime", "CreatorId",
+                    "LastModificationTime", "LastModifierId",
+                    "IsDeleted", "DeleterId", "DeletionTime"
+                )
+                SELECT
+                    gen_random_uuid(),
+                    "Id",
+                    provider_type,
+                    user_id,
+                    "Email",
+                    NULL,
+                    true,
+                    "CreationTime",
+                    "CreationTime",
+                    "CreatorId",
+                    "LastModificationTime",
+                    "LastModifierId",
+                    "IsDeleted",
+                    "DeleterId",
+                    "DeletionTime"
+                FROM customer_profiles
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "customer_external_identities");
+        }
+    }
+}

--- a/DKH.CustomerService.Infrastructure/Persistence/Repositories/CustomerRepository.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/Repositories/CustomerRepository.cs
@@ -86,6 +86,20 @@ public class CustomerRepository(AppDbContext dbContext) : ICustomerRepository
                 cancellationToken);
     }
 
+    public async Task<CustomerProfileEntity?> GetByUserIdWithAllRelationsAsync(
+        Guid storefrontId,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        return await dbContext.CustomerProfiles
+            .Include(p => p.Addresses)
+            .Include(p => p.WishlistItems)
+            .Include(p => p.ExternalIdentities)
+            .FirstOrDefaultAsync(
+                p => p.StorefrontId == storefrontId && p.UserId == userId,
+                cancellationToken);
+    }
+
     public async Task<CustomerProfileEntity> AddAsync(CustomerProfileEntity entity, CancellationToken cancellationToken = default)
     {
         dbContext.CustomerProfiles.Add(entity);

--- a/DKH.CustomerService.Infrastructure/Persistence/Repositories/CustomerRepository.cs
+++ b/DKH.CustomerService.Infrastructure/Persistence/Repositories/CustomerRepository.cs
@@ -47,6 +47,45 @@ public class CustomerRepository(AppDbContext dbContext) : ICustomerRepository
                 cancellationToken);
     }
 
+    public async Task<CustomerProfileEntity?> GetByExternalIdentityAsync(
+        Guid storefrontId,
+        string provider,
+        string providerUserId,
+        CancellationToken cancellationToken = default)
+    {
+        return await dbContext.CustomerProfiles
+            .Include(p => p.ExternalIdentities)
+            .FirstOrDefaultAsync(
+                p => p.StorefrontId == storefrontId &&
+                     p.ExternalIdentities.Any(e => e.Provider == provider && e.ProviderUserId == providerUserId),
+                cancellationToken);
+    }
+
+    public async Task<CustomerProfileEntity?> GetByUserIdWithExternalIdentitiesAsync(
+        Guid storefrontId,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        return await dbContext.CustomerProfiles
+            .Include(p => p.ExternalIdentities)
+            .FirstOrDefaultAsync(
+                p => p.StorefrontId == storefrontId && p.UserId == userId,
+                cancellationToken);
+    }
+
+    public async Task<CustomerProfileEntity?> FindByEmailAcrossProvidersAsync(
+        Guid storefrontId,
+        string email,
+        CancellationToken cancellationToken = default)
+    {
+        return await dbContext.CustomerProfiles
+            .Include(p => p.ExternalIdentities)
+            .FirstOrDefaultAsync(
+                p => p.StorefrontId == storefrontId &&
+                     (p.Email == email || p.ExternalIdentities.Any(e => e.Email == email)),
+                cancellationToken);
+    }
+
     public async Task<CustomerProfileEntity> AddAsync(CustomerProfileEntity entity, CancellationToken cancellationToken = default)
     {
         dbContext.CustomerProfiles.Add(entity);


### PR DESCRIPTION
## Summary
- Add `CustomerExternalIdentityEntity` with EF configuration, migration, and seed from existing data
- Add `IdentityLinkingService` proto contracts: `LinkIdentity`, `UnlinkIdentity`, `ListIdentities`, `FindByExternalIdentity`, `MergeProfiles`
- Implement gRPC service handlers with FluentValidation for all commands/queries
- Add `MergeFrom` domain method to `CustomerProfileEntity` (addresses, wishlist, identities, stats)
- Add `MergeProfilesCommandHandler` with source soft-delete after merge

## Related Issues
- Fixes GZDKH/DKH.CustomerService#22
- Fixes GZDKH/DKH.CustomerService#23
- Fixes GZDKH/DKH.CustomerService#24
- Fixes GZDKH/DKH.CustomerService#31

## Test plan
- [ ] `dotnet build -c Release` passes (0 errors, 0 warnings)
- [ ] `dotnet test` passes
- [ ] Verify migration applies cleanly on fresh DB
- [ ] Verify ExternalIdentities are seeded from existing profiles
- [ ] Test LinkIdentity/UnlinkIdentity/ListIdentities via gRPC
- [ ] Test MergeProfiles: addresses, wishlist, identities transferred; source soft-deleted